### PR TITLE
Add undo/redo feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -479,3 +479,6 @@ saves/
 
 # Compiled story outputs (generated)
 compiled_stories/
+
+# Testing stories
+stories/samples/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Include a `game_logic/` directory inside all generated projects from `bardic init`.
+- **Undo/Redo System** - Players can now rewind and replay choices
+  - `engine.undo()` / `engine.redo()` methods for programmatic control
+  - `engine.can_undo()` / `engine.can_redo()` for UI button state
+  - `GameSnapshot` dataclass captures complete game state (passage, variables, used choices)
+  - Stack-based architecture with configurable depth (default: 50)
+  - Redo stack clears on new choices (timeline branching)
+  - Snapshots taken before navigation for correct restore point
+  - Browser template includes ← → navigation buttons in header
 
 ### Changed
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # Bardic TODO
 
-Last updated: 2025-11-09
+Last updated: 2025-12-20
 
 ## 🐛 Parser Bugs (Found by Tests)
 
@@ -84,10 +84,13 @@ High priority fixes discovered through comprehensive test suite:
   - Dynamically turn off the every-turn passage with @unhook
   - Will need to keep track of these as the parser goes and enact on game loop turn
 
-- [ ] **Undo stacks**
-  - Implement "go back" and undo method in engine with <- UI element
-  - Set up N-length `state` stack, add/discard every "turn" (player action) and pop it on undo being called
-  - Alternatively, just store the deltas? And merge into "base" state. Might be more complicated but would be more memory-efficient.
+- [x] **Undo stacks** - ✅ CORE COMPLETED (Dec 2025)
+  - [x] Engine-side: `GameSnapshot`, `undo()`, `redo()`, `can_undo()`, `can_redo()`
+  - [x] Browser template (`bardic bundle`): ← → buttons in header
+  - [ ] CLI player (`bardic play`): Add undo/redo keyboard shortcuts
+  - [ ] NiceGUI template (`bardic init nicegui`): Add undo/redo buttons
+  - [ ] Reflex template (`bardic init reflex`): Add undo/redo buttons
+  - [ ] React/web template (`bardic init web`): Add undo/redo buttons
 
 ## 📚 Documentation
 

--- a/bardic/templates/browser/engine_browser.py
+++ b/bardic/templates/browser/engine_browser.py
@@ -7,13 +7,15 @@ This version is modified for PyScript/Pyodide browser environment:
 - localStorage-based save/load methods
 """
 
+import ast
+import copy
 import json
-from typing import Dict, Any, List, Optional
-from dataclasses import dataclass
 import traceback
 import uuid
-import ast
+from collections import deque
+from dataclasses import dataclass
 from datetime import datetime
+from typing import Any, Dict, List, Optional
 
 
 @dataclass
@@ -44,6 +46,40 @@ class PassageOutput:
             self.input_directives = []
 
 
+@dataclass
+class GameSnapshot:
+    """
+    Complete snapshot of game state at a point in time.
+
+    Used by the undo/redo system to capture and restore game state.
+    We store full copies (not diffs) for simplicity and reliability.
+
+    Attributes:
+        current_passage: The passage ID at the time of snapshot
+        state: Deep copy of all game variables
+        used_choices: Set of one-time choices that have been used
+    """
+
+    current_passage: str | None
+    state: dict[str, Any]
+    used_choices: set
+
+    @classmethod
+    def from_engine(cls, engine: "BardEngine") -> "GameSnapshot":
+        """Create a snapshot from the current game engine."""
+        return cls(
+            current_passage=engine.current_passage_id,
+            state=copy.deepcopy(engine.state),
+            used_choices=engine.used_choices.copy(),
+        )
+
+    def restore_to(self, engine: "BardEngine") -> None:
+        """Restore this snapshot to the engine."""
+        engine.current_passage_id = self.current_passage
+        engine.state = self.state
+        engine.used_choices = self.used_choices
+
+
 class BardEngine:
     """
     Browser-adapted runtime engine for Bard stories.
@@ -68,12 +104,16 @@ class BardEngine:
         self.passages = story_data["passages"]
         self.current_passage_id = None  # Will be set by goto()
         self.state = {}  # Game state (variables)
-        self.state['_inputs'] = {}  # Initialize empty inputs dict (always available)
+        self.state["_inputs"] = {}  # Initialize empty inputs dict (always available)
         self._local_scope_stack = []  # Stack of local parameter scopes (NEW for passage params)
         self.used_choices = set()  # Track which one-time choices have been used
         self.context = context or {}
         self.evaluate_directives = evaluate_directives
         self._current_output = None  # Cache for current passage output
+
+        # Undo/redo system
+        self.undo_stack: deque[GameSnapshot] = deque(maxlen=50)
+        self.redo_stack: list[GameSnapshot] = []
 
         # Add more frameworks as needed (eg for unity)
         self.framework_processors = {"react": self._process_for_react}
@@ -114,6 +154,7 @@ class BardEngine:
             # In browser mode, modules should already be in sys.modules
             # We use the real __import__ since modules are pre-loaded
             import builtins
+
             import_namespace = {"__builtins__": builtins}
 
             exec(import_code, import_namespace)
@@ -268,15 +309,11 @@ class BardEngine:
 
                 safe_builtins = self._get_safe_builtins()
                 result[param["name"]] = eval(
-                    param["default"],
-                    {"__builtins__": safe_builtins},
-                    eval_context
+                    param["default"], {"__builtins__": safe_builtins}, eval_context
                 )
             else:
                 # Required param not provided
-                raise ValueError(
-                    f"Required parameter '{param['name']}' not provided"
-                )
+                raise ValueError(f"Required parameter '{param['name']}' not provided")
 
         return result
 
@@ -490,10 +527,7 @@ class BardEngine:
             rendered_text, _, _ = self._render_content(choice_text)
 
         # Return choice with rendered text
-        return {
-            **choice,
-            "text": rendered_text
-        }
+        return {**choice, "text": rendered_text}
 
     def _is_choice_available(self, choice: dict) -> bool:
         """Check if a choice should be shown based on its condition and if used (1-time).
@@ -559,26 +593,28 @@ class BardEngine:
             RuntimeError: If a jump loop is detected
         """
         # Parse passage_spec to extract passage_id and args
-        if '(' in passage_spec:
-            paren_start = passage_spec.index('(')
+        if "(" in passage_spec:
+            paren_start = passage_spec.index("(")
 
             # Find matching closing paren
             depth = 0
             paren_end = -1
             for i in range(paren_start, len(passage_spec)):
-                if passage_spec[i] == '(':
+                if passage_spec[i] == "(":
                     depth += 1
-                elif passage_spec[i] == ')':
+                elif passage_spec[i] == ")":
                     depth -= 1
                     if depth == 0:
                         paren_end = i
                         break
 
             if paren_end == -1:
-                raise ValueError(f"Unclosed parenthesis in passage spec: {passage_spec}")
+                raise ValueError(
+                    f"Unclosed parenthesis in passage spec: {passage_spec}"
+                )
 
             passage_id = passage_spec[:paren_start]
-            args_str = passage_spec[paren_start + 1:paren_end]
+            args_str = passage_spec[paren_start + 1 : paren_end]
         else:
             passage_id = passage_spec
             args_str = ""
@@ -600,7 +636,9 @@ class BardEngine:
             safe_builtins = self._get_safe_builtins()
 
             if args_str:
-                arg_dict = self._parse_directive_args(args_str, eval_context, safe_builtins)
+                arg_dict = self._parse_directive_args(
+                    args_str, eval_context, safe_builtins
+                )
             else:
                 arg_dict = {}
 
@@ -643,13 +681,16 @@ class BardEngine:
 
                     # Combine accumulated content with jump result
                     if accumulated_content:
-                        combined = "\n\n".join(accumulated_content + [jump_output.content])
+                        combined = "\n\n".join(
+                            accumulated_content + [jump_output.content]
+                        )
                         jump_output = PassageOutput(
                             content=combined,
                             choices=jump_output.choices,
                             passage_id=jump_output.passage_id,
                             jump_target=None,
-                            render_directives=accumulated_directives + jump_output.render_directives,
+                            render_directives=accumulated_directives
+                            + jump_output.render_directives,
                             input_directives=jump_output.input_directives,
                         )
 
@@ -722,6 +763,8 @@ class BardEngine:
         Use this for: Player making choices in the story.
 
         Tracks one-time choices so they don't appear again.
+        Creates an undo snapshot before navigating.
+        Clears the redo stack (new choice = new timeline).
 
         Args:
             choice_index: Index of the choice (0-based, from filtered choices)
@@ -732,6 +775,12 @@ class BardEngine:
         Raises:
             IndexError: If choice_index is out of range
         """
+        # SNAPSHOT before any changes (for undo)
+        self.snapshot()
+
+        # Clear the redo stack -- making a new choice creates a new timeline
+        self.redo_stack.clear()
+
         # Get filtered choices from cached output
         current_output = self.current()
         filtered_choices = current_output.choices
@@ -775,11 +824,11 @@ class BardEngine:
         Args:
             input_data: Dict mapping input names to values (e.g., {"reader_name": "Alice"})
         """
-        if '_inputs' not in self.state:
-            self.state['_inputs'] = {}
+        if "_inputs" not in self.state:
+            self.state["_inputs"] = {}
 
         # Merge new inputs (overwrites duplicates)
-        self.state['_inputs'].update(input_data)
+        self.state["_inputs"].update(input_data)
 
     def _execute_commands(self, commands: list[dict]) -> None:
         """Execute passage commands (python statements, python blocks, etc)"""
@@ -815,9 +864,17 @@ class BardEngine:
 
             # Sync any new/modified variables back to state
             # Skip private vars (starting with _), context vars (read-only), and local params
-            local_param_names = set(self._local_scope_stack[-1].keys()) if self._local_scope_stack else set()
+            local_param_names = (
+                set(self._local_scope_stack[-1].keys())
+                if self._local_scope_stack
+                else set()
+            )
             for key, value in eval_context.items():
-                if not key.startswith("_") and key not in self.context and key not in local_param_names:
+                if (
+                    not key.startswith("_")
+                    and key not in self.context
+                    and key not in local_param_names
+                ):
                     self.state[key] = value
 
         except Exception as e:
@@ -1134,7 +1191,7 @@ class BardEngine:
                     condition_result = eval(
                         token["condition"],
                         {"__builtins__": safe_builtins},
-                        eval_context
+                        eval_context,
                     )
 
                     # Choose branch based on condition (truthy or falsy)
@@ -1158,18 +1215,25 @@ class BardEngine:
 
                             # Check for format spec in the branch expression
                             if ":" in branch_expr and not any(
-                                op in branch_expr for op in ["==", "!=", "<=", ">=", "::"]
+                                op in branch_expr
+                                for op in ["==", "!=", "<=", ">=", "::"]
                             ):
                                 # Has format spec
                                 colon_idx = branch_expr.find(":")
                                 expr = branch_expr[:colon_idx].strip()
-                                format_spec = branch_expr[colon_idx + 1:].strip()
+                                format_spec = branch_expr[colon_idx + 1 :].strip()
 
-                                value = eval(expr, {"__builtins__": safe_builtins}, eval_context)
+                                value = eval(
+                                    expr, {"__builtins__": safe_builtins}, eval_context
+                                )
                                 result.append(format(value, format_spec))
                             else:
                                 # No format spec
-                                value = eval(branch_expr, {"__builtins__": safe_builtins}, eval_context)
+                                value = eval(
+                                    branch_expr,
+                                    {"__builtins__": safe_builtins},
+                                    eval_context,
+                                )
                                 result.append(str(value))
                         else:
                             # Plain text - add as-is
@@ -1349,7 +1413,9 @@ class BardEngine:
 
                 if result:
                     # This branch is true -- render its content
-                    content, jump_target, directives = self._render_content(branch["content"])
+                    content, jump_target, directives = self._render_content(
+                        branch["content"]
+                    )
 
                     # Add branch choices to directives (if any)
                     if "choices" in branch:
@@ -1375,6 +1441,74 @@ class BardEngine:
             spec = code[colon_idx + 1 :].strip()
             return expr, spec
         return code, None
+
+    def snapshot(self) -> None:
+        """
+        Capture current state to the undo stack.
+
+        Call this BEFORE making any state changes. The snapshot captures
+        the state at the moment before a choice is made, so undo returns
+        the player to that decision point.
+        """
+        snapshot = GameSnapshot.from_engine(self)
+        self.undo_stack.append(snapshot)
+
+    def undo(self) -> bool:
+        """
+        Restore previous state from undo stack.
+
+        Moves current state to redo stack before restoring, so the player
+        can redo if they change their mind.
+
+        Returns:
+            True if undo was successful, False if nothing to undo.
+        """
+        if not self.undo_stack:
+            return False
+
+        # Save current state to redo stack before restoring
+        current = GameSnapshot.from_engine(self)
+        self.redo_stack.append(current)
+
+        # Restore previous state
+        previous = self.undo_stack.pop()
+        previous.restore_to(self)
+
+        # Re-render the restored passage (updates _current_output cache)
+        self._current_output = self._render_passage(self.current_passage_id)
+
+        return True
+
+    def redo(self) -> bool:
+        """
+        Restore next state from redo stack.
+
+        Returns:
+            True if redo was successful, False if nothing to redo.
+        """
+        if not self.redo_stack:
+            return False
+
+        # Save current state to undo stack before restoring
+        current = GameSnapshot.from_engine(self)
+        self.undo_stack.append(current)
+
+        # Restore next state
+        next_state = self.redo_stack.pop()
+        next_state.restore_to(self)
+
+        # Re-render the restored passage
+        self._current_output = self._render_passage(self.current_passage_id)
+
+        return True
+
+    def can_undo(self) -> bool:
+        """Check if undo is available (for UI button state)."""
+        return len(self.undo_stack) > 0
+
+    def can_redo(self) -> bool:
+        """Check if redo is available (for UI button state)."""
+        return len(self.redo_stack) > 0
 
     def get_story_info(self) -> Dict[str, Any]:
         """
@@ -1523,6 +1657,10 @@ class BardEngine:
         self.state = self._deserialize_state(save_data.get("state", {}))
         self.used_choices = set(save_data.get("used_choices", []))
 
+        # Clear undo/redo stacks on load (fresh start, new session)
+        self.undo_stack.clear()
+        self.redo_stack.clear()
+
         # Navigate to saved passage (this re-renders with restored state)
         self.goto(target_passage)
 
@@ -1536,6 +1674,7 @@ class BardEngine:
         try:
             # Try Pyodide's js module first (direct Pyodide)
             from js import localStorage
+
             save_data = self.save_state()
             json_str = json.dumps(save_data)
             localStorage.setItem(f"bardic_save_{slot_name}", json_str)
@@ -1543,6 +1682,7 @@ class BardEngine:
             try:
                 # Fall back to pyscript if available
                 from pyscript import window
+
                 save_data = self.save_state()
                 json_str = json.dumps(save_data)
                 window.localStorage.setItem(f"bardic_save_{slot_name}", json_str)
@@ -1562,6 +1702,7 @@ class BardEngine:
         """
         try:
             from js import localStorage
+
             json_str = localStorage.getItem(f"bardic_save_{slot_name}")
             if json_str:
                 save_data = json.loads(json_str)
@@ -1571,6 +1712,7 @@ class BardEngine:
         except ImportError:
             try:
                 from pyscript import window
+
                 json_str = window.localStorage.getItem(f"bardic_save_{slot_name}")
                 if json_str:
                     save_data = json.loads(json_str)
@@ -1590,6 +1732,7 @@ class BardEngine:
         """
         try:
             from js import localStorage
+
             saves = []
             for i in range(localStorage.length):
                 key = localStorage.key(i)
@@ -1599,6 +1742,7 @@ class BardEngine:
         except ImportError:
             try:
                 from pyscript import window
+
                 saves = []
                 for i in range(window.localStorage.length):
                     key = window.localStorage.key(i)
@@ -1618,10 +1762,12 @@ class BardEngine:
         """
         try:
             from js import localStorage
+
             localStorage.removeItem(f"bardic_save_{slot_name}")
         except ImportError:
             try:
                 from pyscript import window
+
                 window.localStorage.removeItem(f"bardic_save_{slot_name}")
             except ImportError:
                 print("Warning: localStorage not available (not in browser)")

--- a/bardic/templates/browser/index.html
+++ b/bardic/templates/browser/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -8,6 +9,7 @@
     <!-- Game styles -->
     <link rel="stylesheet" href="style.css">
 </head>
+
 <body>
     <!-- Loading screen (shown while Pyodide loads) -->
     <div id="loading">
@@ -27,6 +29,9 @@
         <header>
             <h1 id="game-title">{{GAME_NAME}}</h1>
             <nav class="game-controls">
+                <button id="undo-btn" title="Undo (go back)" disabled>←</button>
+                <button id="redo-btn" title="Redo (go forward)" disabled>→</button>
+                <span class="controls-separator"></span>
                 <button id="save-btn" title="Save game">Save</button>
                 <button id="load-btn" title="Load game">Load</button>
                 <button id="restart-btn" title="Restart game">Restart</button>
@@ -78,7 +83,7 @@
                 updateLoading('Loading packages...', '', 40);
 
                 // Load micropip for package installation
-                await pyodide.loadPackage(['micropip'], { messageCallback: () => {} });
+                await pyodide.loadPackage(['micropip'], { messageCallback: () => { } });
 
                 // Discover and install any .whl packages in the pyodide folder
                 updateLoading('Installing dependencies...', '', 60);
@@ -300,6 +305,9 @@ json.dumps({
             // Scroll to top
             contentDiv.scrollTop = 0;
             window.scrollTo(0, 0);
+
+            // Update undo/redo button states
+            updateUndoRedoButtons();
         }
 
         // Handle player choice
@@ -365,14 +373,45 @@ engine = BardEngine(game_data)
             showNotification('Game restarted');
         }
 
+        // Undo last choice
+        async function undoChoice() {
+            const result = await pyodide.runPythonAsync(`engine.undo()`);
+            if (result) {
+                renderPassage();
+                showNotification('Undid last choice');
+            } else {
+                showNotification('Nothing to undo', true);
+            }
+        }
+
+        // Redo undone choice
+        async function redoChoice() {
+            const result = await pyodide.runPythonAsync(`engine.redo()`);
+            if (result) {
+                renderPassage();
+                showNotification('Redid choice');
+            } else {
+                showNotification('Nothing to redo', true);
+            }
+        }
+
+        // Update undo/redo button states
+        async function updateUndoRedoButtons() {
+            const canUndo = await pyodide.runPythonAsync(`engine.can_undo()`);
+            const canRedo = await pyodide.runPythonAsync(`engine.can_redo()`);
+
+            document.getElementById('undo-btn').disabled = !canUndo;
+            document.getElementById('redo-btn').disabled = !canRedo;
+        }
+
         // Simple markdown to HTML
         function renderMarkdown(text) {
             if (!text) return '';
 
             // Escape HTML
             text = text.replace(/&/g, '&amp;')
-                       .replace(/</g, '&lt;')
-                       .replace(/>/g, '&gt;');
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;');
 
             // Bold: **text**
             text = text.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
@@ -409,10 +448,13 @@ engine = BardEngine(game_data)
             document.getElementById('save-btn').addEventListener('click', saveGame);
             document.getElementById('load-btn').addEventListener('click', loadGame);
             document.getElementById('restart-btn').addEventListener('click', restartGame);
+            document.getElementById('undo-btn').addEventListener('click', undoChoice);
+            document.getElementById('redo-btn').addEventListener('click', redoChoice);
         }
 
         // Start the game
         init();
     </script>
 </body>
+
 </html>

--- a/bardic/templates/browser/style.css
+++ b/bardic/templates/browser/style.css
@@ -49,7 +49,9 @@
    Reset & Base
    ========================================================================= */
 
-*, *::before, *::after {
+*,
+*::before,
+*::after {
     box-sizing: border-box;
 }
 
@@ -135,7 +137,9 @@ body {
 }
 
 @keyframes spin {
-    to { transform: rotate(360deg); }
+    to {
+        transform: rotate(360deg);
+    }
 }
 
 
@@ -192,6 +196,24 @@ header h1 {
 .game-controls button:hover {
     color: var(--accent-color);
     border-color: var(--accent-color);
+}
+
+.game-controls button:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.game-controls button:disabled:hover {
+    color: var(--text-muted);
+    border-color: var(--text-muted);
+}
+
+.controls-separator {
+    width: 1px;
+    height: 24px;
+    background: var(--text-muted);
+    opacity: 0.3;
+    margin: 0 var(--spacing-sm);
 }
 
 
@@ -349,6 +371,7 @@ footer a:hover {
         opacity: 0;
         transform: translateX(-50%) translateY(20px);
     }
+
     to {
         opacity: 1;
         transform: translateX(-50%) translateY(0);
@@ -387,6 +410,7 @@ footer a:hover {
    ========================================================================= */
 
 /* Hide PyScript loading elements */
-py-script, py-config {
+py-script,
+py-config {
     display: none;
 }

--- a/stories/samples/coffee_shop/engine_browser.py
+++ b/stories/samples/coffee_shop/engine_browser.py
@@ -7,13 +7,15 @@ This version is modified for PyScript/Pyodide browser environment:
 - localStorage-based save/load methods
 """
 
+import ast
+import copy
 import json
-from typing import Dict, Any, List, Optional
-from dataclasses import dataclass
 import traceback
 import uuid
-import ast
+from collections import deque
+from dataclasses import dataclass
 from datetime import datetime
+from typing import Any, Dict, List, Optional
 
 
 @dataclass
@@ -44,6 +46,40 @@ class PassageOutput:
             self.input_directives = []
 
 
+@dataclass
+class GameSnapshot:
+    """
+    Complete snapshot of game state at a point in time.
+
+    Used by the undo/redo system to capture and restore game state.
+    We store full copies (not diffs) for simplicity and reliability.
+
+    Attributes:
+        current_passage: The passage ID at the time of snapshot
+        state: Deep copy of all game variables
+        used_choices: Set of one-time choices that have been used
+    """
+
+    current_passage: str | None
+    state: dict[str, Any]
+    used_choices: set
+
+    @classmethod
+    def from_engine(cls, engine: "BardEngine") -> "GameSnapshot":
+        """Create a snapshot from the current game engine."""
+        return cls(
+            current_passage=engine.current_passage_id,
+            state=copy.deepcopy(engine.state),
+            used_choices=engine.used_choices.copy(),
+        )
+
+    def restore_to(self, engine: "BardEngine") -> None:
+        """Restore this snapshot to the engine."""
+        engine.current_passage_id = self.current_passage
+        engine.state = self.state
+        engine.used_choices = self.used_choices
+
+
 class BardEngine:
     """
     Browser-adapted runtime engine for Bard stories.
@@ -68,12 +104,16 @@ class BardEngine:
         self.passages = story_data["passages"]
         self.current_passage_id = None  # Will be set by goto()
         self.state = {}  # Game state (variables)
-        self.state['_inputs'] = {}  # Initialize empty inputs dict (always available)
+        self.state["_inputs"] = {}  # Initialize empty inputs dict (always available)
         self._local_scope_stack = []  # Stack of local parameter scopes (NEW for passage params)
         self.used_choices = set()  # Track which one-time choices have been used
         self.context = context or {}
         self.evaluate_directives = evaluate_directives
         self._current_output = None  # Cache for current passage output
+
+        # Undo/redo system
+        self.undo_stack: deque[GameSnapshot] = deque(maxlen=50)
+        self.redo_stack: list[GameSnapshot] = []
 
         # Add more frameworks as needed (eg for unity)
         self.framework_processors = {"react": self._process_for_react}
@@ -114,6 +154,7 @@ class BardEngine:
             # In browser mode, modules should already be in sys.modules
             # We use the real __import__ since modules are pre-loaded
             import builtins
+
             import_namespace = {"__builtins__": builtins}
 
             exec(import_code, import_namespace)
@@ -268,15 +309,11 @@ class BardEngine:
 
                 safe_builtins = self._get_safe_builtins()
                 result[param["name"]] = eval(
-                    param["default"],
-                    {"__builtins__": safe_builtins},
-                    eval_context
+                    param["default"], {"__builtins__": safe_builtins}, eval_context
                 )
             else:
                 # Required param not provided
-                raise ValueError(
-                    f"Required parameter '{param['name']}' not provided"
-                )
+                raise ValueError(f"Required parameter '{param['name']}' not provided")
 
         return result
 
@@ -490,10 +527,7 @@ class BardEngine:
             rendered_text, _, _ = self._render_content(choice_text)
 
         # Return choice with rendered text
-        return {
-            **choice,
-            "text": rendered_text
-        }
+        return {**choice, "text": rendered_text}
 
     def _is_choice_available(self, choice: dict) -> bool:
         """Check if a choice should be shown based on its condition and if used (1-time).
@@ -559,26 +593,28 @@ class BardEngine:
             RuntimeError: If a jump loop is detected
         """
         # Parse passage_spec to extract passage_id and args
-        if '(' in passage_spec:
-            paren_start = passage_spec.index('(')
+        if "(" in passage_spec:
+            paren_start = passage_spec.index("(")
 
             # Find matching closing paren
             depth = 0
             paren_end = -1
             for i in range(paren_start, len(passage_spec)):
-                if passage_spec[i] == '(':
+                if passage_spec[i] == "(":
                     depth += 1
-                elif passage_spec[i] == ')':
+                elif passage_spec[i] == ")":
                     depth -= 1
                     if depth == 0:
                         paren_end = i
                         break
 
             if paren_end == -1:
-                raise ValueError(f"Unclosed parenthesis in passage spec: {passage_spec}")
+                raise ValueError(
+                    f"Unclosed parenthesis in passage spec: {passage_spec}"
+                )
 
             passage_id = passage_spec[:paren_start]
-            args_str = passage_spec[paren_start + 1:paren_end]
+            args_str = passage_spec[paren_start + 1 : paren_end]
         else:
             passage_id = passage_spec
             args_str = ""
@@ -600,7 +636,9 @@ class BardEngine:
             safe_builtins = self._get_safe_builtins()
 
             if args_str:
-                arg_dict = self._parse_directive_args(args_str, eval_context, safe_builtins)
+                arg_dict = self._parse_directive_args(
+                    args_str, eval_context, safe_builtins
+                )
             else:
                 arg_dict = {}
 
@@ -643,13 +681,16 @@ class BardEngine:
 
                     # Combine accumulated content with jump result
                     if accumulated_content:
-                        combined = "\n\n".join(accumulated_content + [jump_output.content])
+                        combined = "\n\n".join(
+                            accumulated_content + [jump_output.content]
+                        )
                         jump_output = PassageOutput(
                             content=combined,
                             choices=jump_output.choices,
                             passage_id=jump_output.passage_id,
                             jump_target=None,
-                            render_directives=accumulated_directives + jump_output.render_directives,
+                            render_directives=accumulated_directives
+                            + jump_output.render_directives,
                             input_directives=jump_output.input_directives,
                         )
 
@@ -722,6 +763,8 @@ class BardEngine:
         Use this for: Player making choices in the story.
 
         Tracks one-time choices so they don't appear again.
+        Creates an undo snapshot before navigating.
+        Clears the redo stack (new choice = new timeline).
 
         Args:
             choice_index: Index of the choice (0-based, from filtered choices)
@@ -732,6 +775,12 @@ class BardEngine:
         Raises:
             IndexError: If choice_index is out of range
         """
+        # SNAPSHOT before any changes (for undo)
+        self.snapshot()
+
+        # Clear the redo stack -- making a new choice creates a new timeline
+        self.redo_stack.clear()
+
         # Get filtered choices from cached output
         current_output = self.current()
         filtered_choices = current_output.choices
@@ -775,11 +824,11 @@ class BardEngine:
         Args:
             input_data: Dict mapping input names to values (e.g., {"reader_name": "Alice"})
         """
-        if '_inputs' not in self.state:
-            self.state['_inputs'] = {}
+        if "_inputs" not in self.state:
+            self.state["_inputs"] = {}
 
         # Merge new inputs (overwrites duplicates)
-        self.state['_inputs'].update(input_data)
+        self.state["_inputs"].update(input_data)
 
     def _execute_commands(self, commands: list[dict]) -> None:
         """Execute passage commands (python statements, python blocks, etc)"""
@@ -815,9 +864,17 @@ class BardEngine:
 
             # Sync any new/modified variables back to state
             # Skip private vars (starting with _), context vars (read-only), and local params
-            local_param_names = set(self._local_scope_stack[-1].keys()) if self._local_scope_stack else set()
+            local_param_names = (
+                set(self._local_scope_stack[-1].keys())
+                if self._local_scope_stack
+                else set()
+            )
             for key, value in eval_context.items():
-                if not key.startswith("_") and key not in self.context and key not in local_param_names:
+                if (
+                    not key.startswith("_")
+                    and key not in self.context
+                    and key not in local_param_names
+                ):
                     self.state[key] = value
 
         except Exception as e:
@@ -1134,7 +1191,7 @@ class BardEngine:
                     condition_result = eval(
                         token["condition"],
                         {"__builtins__": safe_builtins},
-                        eval_context
+                        eval_context,
                     )
 
                     # Choose branch based on condition (truthy or falsy)
@@ -1158,18 +1215,25 @@ class BardEngine:
 
                             # Check for format spec in the branch expression
                             if ":" in branch_expr and not any(
-                                op in branch_expr for op in ["==", "!=", "<=", ">=", "::"]
+                                op in branch_expr
+                                for op in ["==", "!=", "<=", ">=", "::"]
                             ):
                                 # Has format spec
                                 colon_idx = branch_expr.find(":")
                                 expr = branch_expr[:colon_idx].strip()
-                                format_spec = branch_expr[colon_idx + 1:].strip()
+                                format_spec = branch_expr[colon_idx + 1 :].strip()
 
-                                value = eval(expr, {"__builtins__": safe_builtins}, eval_context)
+                                value = eval(
+                                    expr, {"__builtins__": safe_builtins}, eval_context
+                                )
                                 result.append(format(value, format_spec))
                             else:
                                 # No format spec
-                                value = eval(branch_expr, {"__builtins__": safe_builtins}, eval_context)
+                                value = eval(
+                                    branch_expr,
+                                    {"__builtins__": safe_builtins},
+                                    eval_context,
+                                )
                                 result.append(str(value))
                         else:
                             # Plain text - add as-is
@@ -1349,7 +1413,9 @@ class BardEngine:
 
                 if result:
                     # This branch is true -- render its content
-                    content, jump_target, directives = self._render_content(branch["content"])
+                    content, jump_target, directives = self._render_content(
+                        branch["content"]
+                    )
 
                     # Add branch choices to directives (if any)
                     if "choices" in branch:
@@ -1375,6 +1441,74 @@ class BardEngine:
             spec = code[colon_idx + 1 :].strip()
             return expr, spec
         return code, None
+
+    def snapshot(self) -> None:
+        """
+        Capture current state to the undo stack.
+
+        Call this BEFORE making any state changes. The snapshot captures
+        the state at the moment before a choice is made, so undo returns
+        the player to that decision point.
+        """
+        snapshot = GameSnapshot.from_engine(self)
+        self.undo_stack.append(snapshot)
+
+    def undo(self) -> bool:
+        """
+        Restore previous state from undo stack.
+
+        Moves current state to redo stack before restoring, so the player
+        can redo if they change their mind.
+
+        Returns:
+            True if undo was successful, False if nothing to undo.
+        """
+        if not self.undo_stack:
+            return False
+
+        # Save current state to redo stack before restoring
+        current = GameSnapshot.from_engine(self)
+        self.redo_stack.append(current)
+
+        # Restore previous state
+        previous = self.undo_stack.pop()
+        previous.restore_to(self)
+
+        # Re-render the restored passage (updates _current_output cache)
+        self._current_output = self._render_passage(self.current_passage_id)
+
+        return True
+
+    def redo(self) -> bool:
+        """
+        Restore next state from redo stack.
+
+        Returns:
+            True if redo was successful, False if nothing to redo.
+        """
+        if not self.redo_stack:
+            return False
+
+        # Save current state to undo stack before restoring
+        current = GameSnapshot.from_engine(self)
+        self.undo_stack.append(current)
+
+        # Restore next state
+        next_state = self.redo_stack.pop()
+        next_state.restore_to(self)
+
+        # Re-render the restored passage
+        self._current_output = self._render_passage(self.current_passage_id)
+
+        return True
+
+    def can_undo(self) -> bool:
+        """Check if undo is available (for UI button state)."""
+        return len(self.undo_stack) > 0
+
+    def can_redo(self) -> bool:
+        """Check if redo is available (for UI button state)."""
+        return len(self.redo_stack) > 0
 
     def get_story_info(self) -> Dict[str, Any]:
         """
@@ -1523,6 +1657,10 @@ class BardEngine:
         self.state = self._deserialize_state(save_data.get("state", {}))
         self.used_choices = set(save_data.get("used_choices", []))
 
+        # Clear undo/redo stacks on load (fresh start, new session)
+        self.undo_stack.clear()
+        self.redo_stack.clear()
+
         # Navigate to saved passage (this re-renders with restored state)
         self.goto(target_passage)
 
@@ -1536,6 +1674,7 @@ class BardEngine:
         try:
             # Try Pyodide's js module first (direct Pyodide)
             from js import localStorage
+
             save_data = self.save_state()
             json_str = json.dumps(save_data)
             localStorage.setItem(f"bardic_save_{slot_name}", json_str)
@@ -1543,6 +1682,7 @@ class BardEngine:
             try:
                 # Fall back to pyscript if available
                 from pyscript import window
+
                 save_data = self.save_state()
                 json_str = json.dumps(save_data)
                 window.localStorage.setItem(f"bardic_save_{slot_name}", json_str)
@@ -1562,6 +1702,7 @@ class BardEngine:
         """
         try:
             from js import localStorage
+
             json_str = localStorage.getItem(f"bardic_save_{slot_name}")
             if json_str:
                 save_data = json.loads(json_str)
@@ -1571,6 +1712,7 @@ class BardEngine:
         except ImportError:
             try:
                 from pyscript import window
+
                 json_str = window.localStorage.getItem(f"bardic_save_{slot_name}")
                 if json_str:
                     save_data = json.loads(json_str)
@@ -1590,6 +1732,7 @@ class BardEngine:
         """
         try:
             from js import localStorage
+
             saves = []
             for i in range(localStorage.length):
                 key = localStorage.key(i)
@@ -1599,6 +1742,7 @@ class BardEngine:
         except ImportError:
             try:
                 from pyscript import window
+
                 saves = []
                 for i in range(window.localStorage.length):
                     key = window.localStorage.key(i)
@@ -1618,10 +1762,12 @@ class BardEngine:
         """
         try:
             from js import localStorage
+
             localStorage.removeItem(f"bardic_save_{slot_name}")
         except ImportError:
             try:
                 from pyscript import window
+
                 window.localStorage.removeItem(f"bardic_save_{slot_name}")
             except ImportError:
                 print("Warning: localStorage not available (not in browser)")

--- a/stories/samples/coffee_shop/index.html
+++ b/stories/samples/coffee_shop/index.html
@@ -1,18 +1,20 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>The Coffee Shop</title>
+    <title>The Coffee Shop Encounter</title>
 
     <!-- Game styles -->
     <link rel="stylesheet" href="style.css">
 </head>
+
 <body>
     <!-- Loading screen (shown while Pyodide loads) -->
     <div id="loading">
         <div class="loading-content">
-            <h1>The Coffee Shop</h1>
+            <h1>The Coffee Shop Encounter</h1>
             <p id="loading-status">Initializing...</p>
             <div class="spinner"></div>
             <div class="progress-container">
@@ -25,8 +27,11 @@
     <!-- Game container (hidden until loaded) -->
     <div id="game" style="display: none;">
         <header>
-            <h1 id="game-title">The Coffee Shop</h1>
+            <h1 id="game-title">The Coffee Shop Encounter</h1>
             <nav class="game-controls">
+                <button id="undo-btn" title="Undo (go back)" disabled>←</button>
+                <button id="redo-btn" title="Redo (go forward)" disabled>→</button>
+                <span class="controls-separator"></span>
                 <button id="save-btn" title="Save game">Save</button>
                 <button id="load-btn" title="Load game">Load</button>
                 <button id="restart-btn" title="Restart game">Restart</button>
@@ -78,7 +83,7 @@
                 updateLoading('Loading packages...', '', 40);
 
                 // Load micropip for package installation
-                await pyodide.loadPackage(['micropip'], { messageCallback: () => {} });
+                await pyodide.loadPackage(['micropip'], { messageCallback: () => { } });
 
                 // Discover and install any .whl packages in the pyodide folder
                 updateLoading('Installing dependencies...', '', 60);
@@ -300,6 +305,9 @@ json.dumps({
             // Scroll to top
             contentDiv.scrollTop = 0;
             window.scrollTo(0, 0);
+
+            // Update undo/redo button states
+            updateUndoRedoButtons();
         }
 
         // Handle player choice
@@ -365,14 +373,45 @@ engine = BardEngine(game_data)
             showNotification('Game restarted');
         }
 
+        // Undo last choice
+        async function undoChoice() {
+            const result = await pyodide.runPythonAsync(`engine.undo()`);
+            if (result) {
+                renderPassage();
+                showNotification('Undid last choice');
+            } else {
+                showNotification('Nothing to undo', true);
+            }
+        }
+
+        // Redo undone choice
+        async function redoChoice() {
+            const result = await pyodide.runPythonAsync(`engine.redo()`);
+            if (result) {
+                renderPassage();
+                showNotification('Redid choice');
+            } else {
+                showNotification('Nothing to redo', true);
+            }
+        }
+
+        // Update undo/redo button states
+        async function updateUndoRedoButtons() {
+            const canUndo = await pyodide.runPythonAsync(`engine.can_undo()`);
+            const canRedo = await pyodide.runPythonAsync(`engine.can_redo()`);
+
+            document.getElementById('undo-btn').disabled = !canUndo;
+            document.getElementById('redo-btn').disabled = !canRedo;
+        }
+
         // Simple markdown to HTML
         function renderMarkdown(text) {
             if (!text) return '';
 
             // Escape HTML
             text = text.replace(/&/g, '&amp;')
-                       .replace(/</g, '&lt;')
-                       .replace(/>/g, '&gt;');
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;');
 
             // Bold: **text**
             text = text.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
@@ -409,10 +448,13 @@ engine = BardEngine(game_data)
             document.getElementById('save-btn').addEventListener('click', saveGame);
             document.getElementById('load-btn').addEventListener('click', loadGame);
             document.getElementById('restart-btn').addEventListener('click', restartGame);
+            document.getElementById('undo-btn').addEventListener('click', undoChoice);
+            document.getElementById('redo-btn').addEventListener('click', redoChoice);
         }
 
         // Start the game
         init();
     </script>
 </body>
+
 </html>

--- a/stories/samples/coffee_shop/style.css
+++ b/stories/samples/coffee_shop/style.css
@@ -65,7 +65,9 @@
    Reset & Base
    ========================================================================= */
 
-*, *::before, *::after {
+*,
+*::before,
+*::after {
     box-sizing: border-box;
 }
 
@@ -151,7 +153,9 @@ body {
 }
 
 @keyframes spin {
-    to { transform: rotate(360deg); }
+    to {
+        transform: rotate(360deg);
+    }
 }
 
 
@@ -208,6 +212,24 @@ header h1 {
 .game-controls button:hover {
     color: var(--accent-color);
     border-color: var(--accent-color);
+}
+
+.game-controls button:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.game-controls button:disabled:hover {
+    color: var(--text-muted);
+    border-color: var(--text-muted);
+}
+
+.controls-separator {
+    width: 1px;
+    height: 24px;
+    background: var(--text-muted);
+    opacity: 0.3;
+    margin: 0 var(--spacing-sm);
 }
 
 
@@ -365,6 +387,7 @@ footer a:hover {
         opacity: 0;
         transform: translateX(-50%) translateY(20px);
     }
+
     to {
         opacity: 1;
         transform: translateX(-50%) translateY(0);
@@ -403,6 +426,7 @@ footer a:hover {
    ========================================================================= */
 
 /* Hide PyScript loading elements */
-py-script, py-config {
+py-script,
+py-config {
     display: none;
 }


### PR DESCRIPTION
- **Undo/Redo System** - Players can now rewind and replay choices
  - `engine.undo()` / `engine.redo()` methods for programmatic control
  - `engine.can_undo()` / `engine.can_redo()` for UI button state
  - `GameSnapshot` dataclass captures complete game state (passage, variables, used choices)
  - Stack-based architecture with configurable depth (default: 50)
  - Redo stack clears on new choices (timeline branching)
  - Snapshots taken before navigation for correct restore point
  - Browser template includes ← → navigation buttons in header