### PR TITLE
Add @hook and @unhook directive functionality for event triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Undo/Redo System** - Players can now rewind and replay choices
   - `engine.undo()` / `engine.redo()` methods for programmatic control
   - `engine.can_undo()` / `engine.can_redo()` for UI button state
-  - `GameSnapshot` dataclass captures complete game state (passage, variables, used choices)
+  - `GameSnapshot` dataclass captures complete game state (passage, variables, used choices, hooks)
   - Stack-based architecture with configurable depth (default: 50)
   - Redo stack clears on new choices (timeline branching)
   - Snapshots taken before navigation for correct restore point
   - Browser template includes ← → navigation buttons in header
+
+- **Hooks System** - Background systems that run every turn
+  - `@hook event_name PassageName` - Register a passage to run on an event
+  - `@unhook event_name PassageName` - Unregister a hooked passage
+  - `engine.register_hook()` / `engine.unregister_hook()` for programmatic control
+  - `engine.trigger_event()` executes all passages hooked to an event
+  - Built-in `turn_end` event fires after every `choose()` call
+  - FIFO execution order (first registered, first run)
+  - Idempotent registration (duplicate hooks ignored)
+  - Hooks can self-remove inside `@if` blocks
+  - Hook state included in undo/redo snapshots
 
 ### Changed
 

--- a/TODO.md
+++ b/TODO.md
@@ -79,14 +79,18 @@ High priority fixes discovered through comprehensive test suite:
   - Functions similarly to Ink gathers
   - Might be called @merge?
 
-- [ ] **Hooks and listener system**
-  - Implement @hook and @unhook to run a passage on every (X) event ie. `@hook turn_end HookTimeIncrement`
-  - Dynamically turn off the every-turn passage with @unhook
-  - Will need to keep track of these as the parser goes and enact on game loop turn
+- [x] **Hooks and listener system** - ✅ COMPLETED (Dec 2025)
+  - [x] @hook and @unhook directives in parser
+  - [x] register_hook/unregister_hook/trigger_event in engine
+  - [x] turn_end event fires after every choose()
+  - [x] Hooks work inside @if/@for blocks
+  - [x] Hook state included in undo/redo snapshots
+  - [x] pytest tests: `tests/test_hooks.py` (11 tests)
 
 - [x] **Undo stacks** - ✅ CORE COMPLETED (Dec 2025)
   - [x] Engine-side: `GameSnapshot`, `undo()`, `redo()`, `can_undo()`, `can_redo()`
   - [x] Browser template (`bardic bundle`): ← → buttons in header
+  - [x] pytest tests: `tests/test_undo_redo.py` (14 tests)
   - [ ] CLI player (`bardic play`): Add undo/redo keyboard shortcuts
   - [ ] NiceGUI template (`bardic init nicegui`): Add undo/redo buttons
   - [ ] Reflex template (`bardic init reflex`): Add undo/redo buttons

--- a/stories/test/test_hooks.bard
+++ b/stories/test/test_hooks.bard
@@ -1,0 +1,30 @@
+:: Start
+~ health = 100
+
+Welcome to the poison test!
+
++ [Drink poison] -> Drink_Poison
++ [Go safely] -> Safe
+
+:: Drink_Poison
+@hook turn_end Effect_Poison
+You drink the mysterious vial.
+
++ [Continue] -> Cave
+
+:: Effect_Poison
+You feel the poison burning in your veins.
+~ health = health - 10
+
+:: Safe
+You decide not to drink.
++ [Continue] -> Cave
+
+:: Cave
+The cave is dark and cold.
+{health ? HP: {health} |}
++ [Go deeper] -> Deep
+
+:: Deep
+You venture deeper.
++ [Return] -> Cave

--- a/tests/hooks/test_hook_basic.bard
+++ b/tests/hooks/test_hook_basic.bard
@@ -1,0 +1,22 @@
+:: Start
+Welcome to the hook test!
+@hook turn_end Tick_Clock
+~ turns = 0
+
++ [Continue] -> Room1
+
+:: Tick_Clock
+~ turns = turns + 1
+
+:: Room1
+You are in room 1. Turns: {turns}
++ [Go to room 2] -> Room2
++ [Stay here] -> Room1
+
+:: Room2
+You are in room 2. Turns: {turns}
++ [Go back] -> Room1
++ [End] -> End
+
+:: End
+Game over! Total turns: {turns}

--- a/tests/hooks/test_hook_edge_cases.bard
+++ b/tests/hooks/test_hook_edge_cases.bard
@@ -1,0 +1,40 @@
+:: Start
+Edge case tests.
+~ test_var = 0
+
++ [Test duplicate registration] -> TestDuplicate
++ [Test unhook non-existent] -> TestUnhookMissing
++ [Test hook with underscores] -> TestUnderscores
+
+:: TestDuplicate
+Registering same hook twice...
+@hook turn_end Counter
+@hook turn_end Counter
+~ test_var = 0
++ [Make a choice] -> CheckDuplicate
+
+:: Counter
+~ test_var = test_var + 1
+
+:: CheckDuplicate
+test_var should be 1 (not 2): {test_var}
++ [Back] -> Start
+
+:: TestUnhookMissing
+Unhooking something that was never hooked...
+@unhook turn_end NonExistentHook
+This should not crash!
++ [Back] -> Start
+
+:: TestUnderscores
+Testing hook names with underscores...
+@hook turn_end My_Custom_Hook_Name
++ [Continue] -> CheckUnderscore
+
+:: My_Custom_Hook_Name
+~ test_var = 999
+
+:: CheckUnderscore
+test_var should be 999: {test_var}
+@unhook turn_end My_Custom_Hook_Name
++ [Back] -> Start

--- a/tests/hooks/test_hook_multiple.bard
+++ b/tests/hooks/test_hook_multiple.bard
@@ -1,0 +1,31 @@
+:: Start
+Setting up multiple hooks...
+@hook turn_end Hook_A
+@hook turn_end Hook_B
+@hook turn_end Hook_C
+~ log = []
+
++ [Continue] -> Room1
+
+:: Hook_A
+~ log = log + ["A"]
+
+:: Hook_B
+~ log = log + ["B"]
+
+:: Hook_C
+~ log = log + ["C"]
+
+:: Room1
+Hooks fired: {log}
++ [Remove B] -> RemoveB
++ [Continue] -> Room1
++ [End] -> End
+
+:: RemoveB
+Removing hook B...
+@unhook turn_end Hook_B
++ [Continue] -> Room1
+
+:: End
+Final log: {log}

--- a/tests/hooks/test_hook_self_remove.bard
+++ b/tests/hooks/test_hook_self_remove.bard
@@ -1,0 +1,22 @@
+:: Start
+Testing hook that removes itself...
+~ countdown = 3
+@hook turn_end CountdownHook
+
++ [Continue] -> Room1
+
+:: CountdownHook
+Countdown: {countdown}
+~ countdown = countdown - 1
+@if countdown <= 0:
+@unhook turn_end CountdownHook
+Countdown finished! Hook removed.
+@endif
+
+:: Room1
+Still going...
++ [Continue] -> Room1
++ [End] -> End
+
+:: End
+Done!

--- a/tests/hooks/test_hook_unhook.bard
+++ b/tests/hooks/test_hook_unhook.bard
@@ -1,0 +1,32 @@
+:: Start
+You feel fine.
+~ health = 100
++ [Drink poison] -> DrinkPoison
++ [Skip poison] -> Safe
+
+:: DrinkPoison
+You drink the mysterious vial!
+@hook turn_end PoisonEffect
++ [Continue] -> Wandering
+
+:: Safe
+You wisely avoid the vial.
++ [Continue] -> Wandering
+
+:: Wandering
+Your health: {health}
++ [Drink antidote] -> DrinkAntidote
++ [Keep wandering] -> Wandering
++ [End] -> End
+
+:: PoisonEffect
+The poison burns! You lose 10 HP.
+~ health = health - 10
+
+:: DrinkAntidote
+You drink the antidote!
+@unhook turn_end PoisonEffect
++ [Continue] -> Wandering
+
+:: End
+Final health: {health}

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,270 @@
+"""Test the Bardic hooks system."""
+
+import pytest
+from bardic.runtime.engine import BardEngine
+
+
+@pytest.fixture
+def hook_story():
+    """A story with hook functionality for testing."""
+    return {
+        "version": "0.1.0",
+        "initial_passage": "Start",
+        "passages": {
+            "Start": {
+                "id": "Start",
+                "content": [{"type": "text", "value": "Welcome!"}],
+                "choices": [
+                    {"text": "Register hook", "target": "RegisterHook"},
+                    {"text": "Skip", "target": "Room"},
+                ],
+                "execute": [{"type": "python_statement", "code": "counter = 0"}],
+            },
+            "RegisterHook": {
+                "id": "RegisterHook",
+                "content": [{"type": "text", "value": "Hook registered."}],
+                "choices": [{"text": "Continue", "target": "Room"}],
+                "execute": [{"type": "hook", "action": "add", "event": "turn_end", "target": "CounterHook"}],
+            },
+            "CounterHook": {
+                "id": "CounterHook",
+                "content": [],
+                "choices": [],
+                "execute": [{"type": "python_statement", "code": "counter = counter + 1"}],
+            },
+            "Room": {
+                "id": "Room",
+                "content": [{"type": "text", "value": "You are in a room."}],
+                "choices": [
+                    {"text": "Stay", "target": "Room"},
+                    {"text": "Unregister", "target": "Unregister"},
+                ],
+                "execute": [],
+            },
+            "Unregister": {
+                "id": "Unregister",
+                "content": [{"type": "text", "value": "Hook removed."}],
+                "choices": [{"text": "Continue", "target": "Room"}],
+                "execute": [{"type": "hook", "action": "remove", "event": "turn_end", "target": "CounterHook"}],
+            },
+        },
+    }
+
+
+class TestHookRegistration:
+    """Test hook registration and unregistration."""
+
+    def test_register_hook_adds_to_hooks_dict(self, hook_story):
+        """register_hook() should add passage to hooks dictionary."""
+        engine = BardEngine(hook_story)
+
+        # When: We register a hook
+        engine.register_hook("test_event", "SomePassage")
+
+        # Then: It should be in the hooks dict
+        assert "test_event" in engine.hooks
+        assert "SomePassage" in engine.hooks["test_event"]
+
+    def test_register_hook_is_idempotent(self, hook_story):
+        """Registering the same hook twice should not create duplicates."""
+        engine = BardEngine(hook_story)
+
+        # When: We register the same hook twice
+        engine.register_hook("test_event", "SomePassage")
+        engine.register_hook("test_event", "SomePassage")
+
+        # Then: It should only appear once
+        assert engine.hooks["test_event"].count("SomePassage") == 1
+
+    def test_unregister_hook_removes_from_hooks_dict(self, hook_story):
+        """unregister_hook() should remove passage from hooks dictionary."""
+        engine = BardEngine(hook_story)
+        engine.register_hook("test_event", "SomePassage")
+
+        # When: We unregister the hook
+        engine.unregister_hook("test_event", "SomePassage")
+
+        # Then: It should be removed
+        assert "SomePassage" not in engine.hooks.get("test_event", [])
+
+    def test_unregister_nonexistent_hook_does_not_crash(self, hook_story):
+        """Unregistering a hook that doesn't exist should not raise."""
+        engine = BardEngine(hook_story)
+
+        # When/Then: Unregistering non-existent hook should not raise
+        engine.unregister_hook("nonexistent_event", "NonexistentPassage")
+        # No exception = pass
+
+
+class TestHookExecution:
+    """Test that hooks fire correctly."""
+
+    def test_hook_fires_on_turn_end(self, hook_story):
+        """Hooks registered to turn_end should fire after choose()."""
+        engine = BardEngine(hook_story)
+        assert engine.state.get("counter") == 0
+
+        # When: We register hook and make a choice
+        engine.choose(0)  # Register hook
+        # Hook fires at end of this turn
+        assert engine.state.get("counter") == 1
+
+        # And: We make another choice
+        engine.choose(0)  # Continue to Room
+        # Hook fires again
+        assert engine.state.get("counter") == 2
+
+    def test_hook_stops_firing_after_unregister(self, hook_story):
+        """Hooks should stop firing after being unregistered."""
+        engine = BardEngine(hook_story)
+
+        # Setup: Register hook and verify it fires
+        engine.choose(0)  # Register hook -> counter = 1
+        engine.choose(0)  # Continue to Room -> counter = 2
+        counter_before = engine.state.get("counter")
+        assert counter_before == 2
+
+        # When: We unregister the hook
+        # The @unhook runs during passage execution, BEFORE turn_end fires
+        # So the hook is already gone when turn_end triggers
+        engine.choose(1)  # Unregister -> counter stays 2 (hook already removed)
+
+        counter_after_unregister = engine.state.get("counter")
+        assert counter_after_unregister == 2  # Hook didn't fire (was unregistered first)
+
+        # And: Further choices should not trigger the hook
+        engine.choose(0)  # Continue to Room
+        counter_final = engine.state.get("counter")
+        assert counter_final == 2  # Still 2, hook is gone
+
+    def test_multiple_hooks_fire_in_order(self, hook_story):
+        """Multiple hooks on same event should fire in FIFO order."""
+        engine = BardEngine(hook_story)
+        engine.state["log"] = []
+
+        # Create passages that log their execution
+        engine.passages["HookA"] = {
+            "id": "HookA",
+            "content": [],
+            "choices": [],
+            "execute": [{"type": "python_statement", "code": "log.append('A')"}],
+        }
+        engine.passages["HookB"] = {
+            "id": "HookB",
+            "content": [],
+            "choices": [],
+            "execute": [{"type": "python_statement", "code": "log.append('B')"}],
+        }
+
+        # When: We register hooks in order A, B
+        engine.register_hook("turn_end", "HookA")
+        engine.register_hook("turn_end", "HookB")
+
+        # And: Trigger the event
+        engine.trigger_event("turn_end")
+
+        # Then: They should have fired in order
+        assert engine.state["log"] == ["A", "B"]
+
+
+class TestHookDirectiveParsing:
+    """Test that @hook/@unhook directives are parsed correctly."""
+
+    def test_hook_directive_in_passage(self, compile_string):
+        """@hook directive should create a hook command in execute."""
+        story = compile_string("""
+:: Start
+@hook turn_end MyHook
+Hello!
++ [Continue] -> End
+
+:: MyHook
+Hook content.
+
+:: End
+The end.
+""")
+        # Then: Start passage should have hook in execute
+        start = story["passages"]["Start"]
+        hook_cmds = [cmd for cmd in start["execute"] if cmd.get("type") == "hook"]
+        assert len(hook_cmds) == 1
+        assert hook_cmds[0]["action"] == "add"
+        assert hook_cmds[0]["event"] == "turn_end"
+        assert hook_cmds[0]["target"] == "MyHook"
+
+    def test_unhook_directive_in_passage(self, compile_string):
+        """@unhook directive should create a hook remove command in execute."""
+        story = compile_string("""
+:: Start
+@unhook turn_end MyHook
+Hello!
++ [Continue] -> End
+
+:: End
+The end.
+""")
+        # Then: Start passage should have unhook in execute
+        start = story["passages"]["Start"]
+        hook_cmds = [cmd for cmd in start["execute"] if cmd.get("type") == "hook"]
+        assert len(hook_cmds) == 1
+        assert hook_cmds[0]["action"] == "remove"
+        assert hook_cmds[0]["event"] == "turn_end"
+        assert hook_cmds[0]["target"] == "MyHook"
+
+    def test_hook_directive_inside_conditional(self, compile_string):
+        """@hook inside @if block should be parsed as hook token, not text."""
+        story = compile_string("""
+:: Start
+~ should_hook = True
+@if should_hook:
+@hook turn_end MyHook
+@endif
++ [Continue] -> End
+
+:: MyHook
+Hook passage.
+
+:: End
+Done.
+""")
+        # Then: The conditional branch should contain a hook token
+        start = story["passages"]["Start"]
+        conditional = None
+        for token in start["content"]:
+            if token.get("type") == "conditional":
+                conditional = token
+                break
+
+        assert conditional is not None
+        branch_content = conditional["branches"][0]["content"]
+        hook_tokens = [t for t in branch_content if t.get("type") == "hook"]
+        assert len(hook_tokens) == 1
+        assert hook_tokens[0]["action"] == "add"
+
+    def test_unhook_directive_inside_loop(self, compile_string):
+        """@unhook inside @for block should be parsed as hook token."""
+        story = compile_string("""
+:: Start
+~ hooks_to_remove = ["HookA", "HookB"]
+@for hook in hooks_to_remove:
+@unhook turn_end {hook}
+@endfor
++ [Continue] -> End
+
+:: End
+Done.
+""")
+        # Then: The loop should contain unhook tokens
+        start = story["passages"]["Start"]
+        loop = None
+        for token in start["content"]:
+            if token.get("type") == "for_loop":
+                loop = token
+                break
+
+        assert loop is not None
+        # Note: The loop content has @unhook with {hook} which may need expression evaluation
+        # For now just verify it's parsed as a hook type, not text
+        hook_tokens = [t for t in loop["content"] if t.get("type") == "hook"]
+        assert len(hook_tokens) == 1
+        assert hook_tokens[0]["action"] == "remove"

--- a/tests/test_undo_redo.py
+++ b/tests/test_undo_redo.py
@@ -1,0 +1,288 @@
+"""Test the Bardic undo/redo system."""
+
+import pytest
+from bardic.runtime.engine import BardEngine
+
+
+@pytest.fixture
+def undo_story():
+    """A story for testing undo/redo functionality."""
+    return {
+        "version": "0.1.0",
+        "initial_passage": "Start",
+        "passages": {
+            "Start": {
+                "id": "Start",
+                "content": [{"type": "text", "value": "You are at the start."}],
+                "choices": [
+                    {"text": "Go to A", "target": "PassageA"},
+                    {"text": "Go to B", "target": "PassageB"},
+                ],
+                "execute": [{"type": "python_statement", "code": "visited = ['Start']"}],
+            },
+            "PassageA": {
+                "id": "PassageA",
+                "content": [{"type": "text", "value": "You are at passage A."}],
+                "choices": [
+                    {"text": "Go to C", "target": "PassageC"},
+                    {"text": "Go to D", "target": "PassageD"},
+                ],
+                "execute": [{"type": "python_statement", "code": "visited.append('A')"}],
+            },
+            "PassageB": {
+                "id": "PassageB",
+                "content": [{"type": "text", "value": "You are at passage B."}],
+                "choices": [{"text": "Go to C", "target": "PassageC"}],
+                "execute": [{"type": "python_statement", "code": "visited.append('B')"}],
+            },
+            "PassageC": {
+                "id": "PassageC",
+                "content": [{"type": "text", "value": "You are at passage C."}],
+                "choices": [],
+                "execute": [{"type": "python_statement", "code": "visited.append('C')"}],
+            },
+            "PassageD": {
+                "id": "PassageD",
+                "content": [{"type": "text", "value": "You are at passage D."}],
+                "choices": [],
+                "execute": [{"type": "python_statement", "code": "visited.append('D')"}],
+            },
+        },
+    }
+
+
+class TestUndoBasics:
+    """Test basic undo functionality."""
+
+    def test_can_undo_is_false_at_start(self, undo_story):
+        """can_undo() should return False when no choices have been made."""
+        engine = BardEngine(undo_story)
+        assert engine.can_undo() is False
+
+    def test_can_undo_is_true_after_choice(self, undo_story):
+        """can_undo() should return True after making a choice."""
+        engine = BardEngine(undo_story)
+        engine.choose(0)  # Go to A
+        assert engine.can_undo() is True
+
+    def test_undo_returns_to_previous_passage(self, undo_story):
+        """undo() should return to the previous passage."""
+        engine = BardEngine(undo_story)
+
+        # Make a choice
+        engine.choose(0)  # Go to A
+        assert engine.current().passage_id == "PassageA"
+
+        # Undo
+        result = engine.undo()
+        assert result is True
+        assert engine.current().passage_id == "Start"
+
+    def test_undo_restores_state(self, undo_story):
+        """undo() should restore the previous state."""
+        engine = BardEngine(undo_story)
+        assert engine.state["visited"] == ["Start"]
+
+        # Make a choice (modifies state)
+        engine.choose(0)  # Go to A
+        assert engine.state["visited"] == ["Start", "A"]
+
+        # Undo
+        engine.undo()
+        assert engine.state["visited"] == ["Start"]
+
+    def test_undo_returns_false_when_empty(self, undo_story):
+        """undo() should return False when there's nothing to undo."""
+        engine = BardEngine(undo_story)
+        result = engine.undo()
+        assert result is False
+
+    def test_multiple_undos(self, undo_story):
+        """Multiple undos should walk back through history."""
+        engine = BardEngine(undo_story)
+
+        # Make multiple choices
+        engine.choose(0)  # Start -> A
+        engine.choose(0)  # A -> C
+        assert engine.current().passage_id == "PassageC"
+        assert engine.state["visited"] == ["Start", "A", "C"]
+
+        # Undo twice
+        engine.undo()
+        assert engine.current().passage_id == "PassageA"
+        assert engine.state["visited"] == ["Start", "A"]
+
+        engine.undo()
+        assert engine.current().passage_id == "Start"
+        assert engine.state["visited"] == ["Start"]
+
+
+class TestRedoBasics:
+    """Test basic redo functionality."""
+
+    def test_can_redo_is_false_at_start(self, undo_story):
+        """can_redo() should return False when nothing has been undone."""
+        engine = BardEngine(undo_story)
+        assert engine.can_redo() is False
+
+    def test_can_redo_is_true_after_undo(self, undo_story):
+        """can_redo() should return True after undoing."""
+        engine = BardEngine(undo_story)
+        engine.choose(0)
+        engine.undo()
+        assert engine.can_redo() is True
+
+    def test_redo_returns_to_undone_state(self, undo_story):
+        """redo() should return to the state before undo."""
+        engine = BardEngine(undo_story)
+
+        # Make a choice, then undo
+        engine.choose(0)  # Go to A
+        engine.undo()
+        assert engine.current().passage_id == "Start"
+
+        # Redo
+        result = engine.redo()
+        assert result is True
+        assert engine.current().passage_id == "PassageA"
+        assert engine.state["visited"] == ["Start", "A"]
+
+    def test_redo_returns_false_when_empty(self, undo_story):
+        """redo() should return False when there's nothing to redo."""
+        engine = BardEngine(undo_story)
+        result = engine.redo()
+        assert result is False
+
+    def test_new_choice_clears_redo_stack(self, undo_story):
+        """Making a new choice after undo should clear the redo stack."""
+        engine = BardEngine(undo_story)
+
+        # Make choice, undo, make different choice
+        engine.choose(0)  # Go to A
+        engine.undo()
+        engine.choose(1)  # Go to B (different choice)
+
+        # Redo should now be empty
+        assert engine.can_redo() is False
+
+
+class TestUndoRedoWithHooks:
+    """Test that undo/redo properly handles hook state."""
+
+    @pytest.fixture
+    def hook_undo_story(self):
+        """Story with hooks for testing undo/redo interaction."""
+        return {
+            "version": "0.1.0",
+            "initial_passage": "Start",
+            "passages": {
+                "Start": {
+                    "id": "Start",
+                    "content": [{"type": "text", "value": "Start."}],
+                    "choices": [{"text": "Register hook", "target": "Register"}],
+                    "execute": [{"type": "python_statement", "code": "counter = 0"}],
+                },
+                "Register": {
+                    "id": "Register",
+                    "content": [{"type": "text", "value": "Hook registered."}],
+                    "choices": [{"text": "Continue", "target": "Room"}],
+                    "execute": [{"type": "hook", "action": "add", "event": "turn_end", "target": "Counter"}],
+                },
+                "Counter": {
+                    "id": "Counter",
+                    "content": [],
+                    "choices": [],
+                    "execute": [{"type": "python_statement", "code": "counter = counter + 1"}],
+                },
+                "Room": {
+                    "id": "Room",
+                    "content": [{"type": "text", "value": "Room."}],
+                    "choices": [{"text": "Stay", "target": "Room"}],
+                    "execute": [],
+                },
+            },
+        }
+
+    def test_undo_restores_hook_state(self, hook_undo_story):
+        """Undoing should restore hooks to their previous state."""
+        engine = BardEngine(hook_undo_story)
+
+        # Initially no hooks
+        assert "turn_end" not in engine.hooks or len(engine.hooks.get("turn_end", [])) == 0
+
+        # Register hook
+        engine.choose(0)  # Go to Register
+        assert "Counter" in engine.hooks.get("turn_end", [])
+
+        # Undo - should remove the hook
+        engine.undo()
+        assert "Counter" not in engine.hooks.get("turn_end", [])
+
+
+class TestUndoStackLimit:
+    """Test that undo stack respects size limits."""
+
+    def test_undo_stack_is_bounded(self, undo_story):
+        """Undo stack should not grow beyond its limit."""
+        engine = BardEngine(undo_story)
+
+        # The default limit is 50, but we'll just verify the deque has maxlen
+        assert hasattr(engine.undo_stack, 'maxlen')
+        assert engine.undo_stack.maxlen == 50
+
+
+class TestSnapshotIntegrity:
+    """Test that snapshots capture complete state."""
+
+    def test_snapshot_captures_used_choices(self, simple_story_with_sticky):
+        """Snapshots should capture one-time choice usage."""
+        engine = BardEngine(simple_story_with_sticky)
+
+        # Use a one-time choice
+        engine.choose(0)  # Use the one-time choice
+
+        # The choice should be marked as used
+        assert len(engine.used_choices) > 0
+        used_before = engine.used_choices.copy()
+
+        # Make another choice
+        engine.choose(0)
+
+        # Undo back
+        engine.undo()
+        engine.undo()
+
+        # used_choices should be restored
+        assert engine.used_choices == set()  # Back to start, nothing used
+
+
+@pytest.fixture
+def simple_story_with_sticky():
+    """Story with one-time (non-sticky) choices for testing."""
+    return {
+        "version": "0.1.0",
+        "initial_passage": "Start",
+        "passages": {
+            "Start": {
+                "id": "Start",
+                "content": [{"type": "text", "value": "Start."}],
+                "choices": [
+                    {"text": "One-time choice", "target": "Middle", "sticky": False},
+                    {"text": "Regular choice", "target": "Middle", "sticky": True},
+                ],
+                "execute": [],
+            },
+            "Middle": {
+                "id": "Middle",
+                "content": [{"type": "text", "value": "Middle."}],
+                "choices": [{"text": "Continue", "target": "End"}],
+                "execute": [],
+            },
+            "End": {
+                "id": "End",
+                "content": [{"type": "text", "value": "End."}],
+                "choices": [],
+                "execute": [],
+            },
+        },
+    }


### PR DESCRIPTION
- **Hooks System** - Background systems that run every turn
  - `@hook event_name PassageName` - Register a passage to run on an event
  - `@unhook event_name PassageName` - Unregister a hooked passage
  - `engine.register_hook()` / `engine.unregister_hook()` for programmatic control
  - `engine.trigger_event()` executes all passages hooked to an event
  - Built-in `turn_end` event fires after every `choose()` call
  - FIFO execution order (first registered, first run)
  - Idempotent registration (duplicate hooks ignored)
  - Hooks can self-remove inside `@if` blocks
  - Hook state included in undo/redo snapshots