### PR TITLE
Implement joins and join-choices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Hooks can self-remove inside `@if` blocks
   - Hook state included in undo/redo snapshots
 
+- **@join Directive** - Inline choice blocks that merge back together (like Ink gathers)
+  - `+ [Choice] -> @join` with indented block content below the choice
+  - `@join` marker where all choices merge back together
+  - Block content renders only when that choice is selected
+  - Variables set in blocks persist after the merge
+  - Multiple sequential `@join` markers per passage (sections)
+  - Works with conditional choices (`+ {cond} [Text] -> @join`)
+  - Works with one-time choices (`* [Text] -> @join`)
+  - Compatible with hooks (`@hook`/`@unhook` in blocks)
+  - Full undo/redo support (section index in snapshots)
+  - pytest tests: `tests/test_join.py`
+
 ### Changed
 
 ### Fixed

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # Bardic TODO
 
-Last updated: 2025-12-20
+Last updated: 2025-12-27
 
 ## 🐛 Parser Bugs (Found by Tests)
 
@@ -73,11 +73,17 @@ High priority fixes discovered through comprehensive test suite:
   - Consider caching for @include resolution
   - Profile runtime rendering for bottlenecks
 
-- [ ] **Mini-nodes and joins**
-  - Implement nameless mini-nodes with choice syntax + [Text] -> @join
-  - Afterwards collect all of the above "stay here" choices with @join (text)
-  - Functions similarly to Ink gathers
-  - Might be called @merge?
+- [x] **@join directive (inline choice blocks)** - ✅ COMPLETED (Dec 2025)
+  - [x] `+ [Text] -> @join` with indented block content
+  - [x] `@join` marker where choices merge back together
+  - [x] Block content/variables execute when choice selected
+  - [x] Multiple sequential @join markers (sections)
+  - [x] Works with conditional choices, one-time choices, hooks
+  - [x] Full undo/redo support (section index in snapshots)
+  - [x] pytest tests: `tests/test_join.py`
+
+- [ ] **Repeatable menus**
+  - Implement repeatable choices in "menu" blocks to be used in other passages
 
 - [x] **Hooks and listener system** - ✅ COMPLETED (Dec 2025)
   - [x] @hook and @unhook directives in parser
@@ -96,9 +102,18 @@ High priority fixes discovered through comprehensive test suite:
   - [ ] Reflex template (`bardic init reflex`): Add undo/redo buttons
   - [ ] React/web template (`bardic init web`): Add undo/redo buttons
 
+- [ ] Improve implementation of "engine copy" for bundle distribution
+  - Current process requires double-updating for all main engine changes
+
 ## 📚 Documentation
 
 - [ ] Tutorial on new distribution method (HTML)
+
+- [ ] Docs on new features
+  - [ ] Undo/redo
+  - [ ] hook/unhook
+  - [ ] @join directive
+  - [ ] Repeatable choices (menus)
 
 - [ ] **Tutorial Part 3C"" - Needs updating
   - Update final story and intermediate code examples to use for-loop generation of choices (iterating over the list of items) with `{cond}` pre-conditionals

--- a/bardic/compiler/parsing/validation.py
+++ b/bardic/compiler/parsing/validation.py
@@ -8,8 +8,11 @@ from .errors import format_error
 
 
 def validate_choice_syntax(
-    line: str, line_num: int, lines: List[str], filename: Optional[str] = None,
-    line_map: Optional[List] = None
+    line: str,
+    line_num: int,
+    lines: List[str],
+    filename: Optional[str] = None,
+    line_map: Optional[List] = None,
 ) -> None:
     """
     Validate choice line syntax before parsing.
@@ -254,7 +257,7 @@ def validate_passage_name(
     line_num: int,
     lines: List[str],
     filename: Optional[str] = None,
-    line_map: Optional[List] = None
+    line_map: Optional[List] = None,
 ) -> None:
     """
     Validate that a passage name follows strict naming rules.
@@ -316,7 +319,7 @@ def validate_passage_name(
             for i, char in enumerate(passage_name):
                 if not (char.isalnum() or char in "_."):
                     suggestion = (
-                        f"Invalid character '{char}' at position {i+1}. "
+                        f"Invalid character '{char}' at position {i + 1}. "
                         f"Passage names can only contain letters, numbers, underscores, and dots."
                     )
                     break
@@ -543,7 +546,7 @@ def check_duplicate_passages(
     passage_locations: Dict[str, List[int]],
     lines: List[str],
     filename: Optional[str] = None,
-    line_map: Optional[List] = None
+    line_map: Optional[List] = None,
 ) -> None:
     """
     Check for duplicate passage names and error with complete summary.
@@ -577,7 +580,9 @@ def check_duplicate_passages(
 
     # List each duplicate with all its locations
     for passage_name, locations in sorted(duplicates.items()):
-        error_parts.append(f"  Passage '{passage_name}' defined {len(locations)} times:\n")
+        error_parts.append(
+            f"  Passage '{passage_name}' defined {len(locations)} times:\n"
+        )
         for i, line_num in enumerate(locations):
             # line_num is 1-indexed, convert to 0-indexed for line_map lookup
             line_idx = line_num - 1
@@ -595,13 +600,19 @@ def check_duplicate_passages(
             # Show snippet of that line
             line_content = lines[line_idx].strip() if line_idx < len(lines) else ""
             if i == 0:
-                error_parts.append(f"    Line {display_line:4}{file_prefix}: {line_content}  ← First definition\n")
+                error_parts.append(
+                    f"    Line {display_line:4}{file_prefix}: {line_content}  ← First definition\n"
+                )
             else:
-                error_parts.append(f"    Line {display_line:4}{file_prefix}: {line_content}  ← Duplicate!\n")
+                error_parts.append(
+                    f"    Line {display_line:4}{file_prefix}: {line_content}  ← Duplicate!\n"
+                )
         error_parts.append("\n")
 
     error_parts.append("  Hint: Each passage must have a unique name.\n")
-    error_parts.append("        Consider renaming duplicates or removing redundant definitions.\n")
+    error_parts.append(
+        "        Consider renaming duplicates or removing redundant definitions.\n"
+    )
 
     raise ValueError("".join(error_parts))
 
@@ -609,7 +620,7 @@ def check_duplicate_passages(
 def validate_passage_arguments(
     passages: Dict[str, Any],
     filename: Optional[str] = None,
-    line_map: Optional[List] = None
+    line_map: Optional[List] = None,
 ) -> None:
     """
     Validate that all passage calls provide required arguments.
@@ -642,7 +653,7 @@ def validate_passage_arguments(
                 caller_passage=passage_id,
                 call_context=f"choice {choice_idx + 1}",
                 filename=filename,
-                line_map=line_map
+                line_map=line_map,
             )
 
         # Check all jumps
@@ -655,7 +666,7 @@ def validate_passage_arguments(
                     caller_passage=passage_id,
                     call_context="immediate jump",
                     filename=filename,
-                    line_map=line_map
+                    line_map=line_map,
                 )
 
 
@@ -666,7 +677,7 @@ def _validate_single_call(
     caller_passage: str,
     call_context: str,
     filename: Optional[str],
-    line_map: Optional[List]
+    line_map: Optional[List],
 ) -> None:
     """
     Validate a single passage call.
@@ -685,11 +696,19 @@ def _validate_single_call(
     """
     import ast
 
+    # Skip validation for special reserved targets
+    if target == "@join":
+        return
+
     # 1. Check target passage exists
     if target not in passages:
         # Find similar passage names for helpful suggestion
         similar = _find_similar_passages(target, passages)
-        suggestion = f"Did you mean: {', '.join(similar)}?" if similar else "Check passage name spelling"
+        suggestion = (
+            f"Did you mean: {', '.join(similar)}?"
+            if similar
+            else "Check passage name spelling"
+        )
 
         raise SyntaxError(
             f"In passage '{caller_passage}' ({call_context}): "
@@ -714,7 +733,7 @@ def _validate_single_call(
     try:
         # Parse as function call to analyze structure
         call_str = f"_temp_({args_str})" if args_str else "_temp_()"
-        tree = ast.parse(call_str, mode='eval')
+        tree = ast.parse(call_str, mode="eval")
         call_node = tree.body
 
         positional_count = len(call_node.args)
@@ -781,7 +800,9 @@ def _validate_single_call(
             )
 
 
-def _find_similar_passages(target: str, passages: Dict[str, Any], max_results: int = 3) -> List[str]:
+def _find_similar_passages(
+    target: str, passages: Dict[str, Any], max_results: int = 3
+) -> List[str]:
     """
     Find passage names similar to target using basic string similarity.
 

--- a/stories/test/test_basic_join.bard
+++ b/stories/test/test_basic_join.bard
@@ -1,0 +1,17 @@
+:: Start
+Welcome! Choose your fruit.
+
++ [Apple] -> @join
+    You pick up the red apple.
+    ~ choice = "apple"
+
++ [Pear] -> @join
+    You grab the green pear.
+    ~ choice = "pear"
+
+@join
+You chose the {choice}. Delicious!
++ [Continue] -> End
+
+:: End
+Thanks for playing!

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -1,0 +1,430 @@
+"""Test the Bardic @join directive system."""
+
+import pytest
+from bardic.runtime.engine import BardEngine
+
+
+@pytest.fixture
+def basic_join_story():
+    """A story with basic @join functionality."""
+    return {
+        "version": "0.1.0",
+        "initial_passage": "Start",
+        "passages": {
+            "Start": {
+                "id": "Start",
+                "content": [
+                    {"type": "text", "value": "Choose your fruit."},
+                    {"type": "text", "value": "\n"},
+                    {"type": "join_marker", "id": 0},
+                    {"type": "text", "value": "You chose the "},
+                    {"type": "expression", "code": "choice"},
+                    {"type": "text", "value": "."},
+                    {"type": "text", "value": "\n"},
+                ],
+                "choices": [
+                    {
+                        "text": [{"type": "text", "value": "Apple"}],
+                        "target": "@join",
+                        "sticky": True,
+                        "section": 0,
+                        "block_content": [
+                            {"type": "text", "value": "You pick the apple."},
+                            {"type": "text", "value": "\n"},
+                            {"type": "python_statement", "code": "choice = 'apple'"},
+                        ],
+                    },
+                    {
+                        "text": [{"type": "text", "value": "Pear"}],
+                        "target": "@join",
+                        "sticky": True,
+                        "section": 0,
+                        "block_content": [
+                            {"type": "text", "value": "You pick the pear."},
+                            {"type": "text", "value": "\n"},
+                            {"type": "python_statement", "code": "choice = 'pear'"},
+                        ],
+                    },
+                    {
+                        "text": [{"type": "text", "value": "Continue"}],
+                        "target": "End",
+                        "sticky": True,
+                        "section": 1,
+                    },
+                ],
+                "execute": [],
+            },
+            "End": {
+                "id": "End",
+                "content": [{"type": "text", "value": "Done."}],
+                "choices": [],
+                "execute": [],
+            },
+        },
+    }
+
+
+class TestJoinBasics:
+    """Test basic @join functionality."""
+
+    def test_initial_shows_section_0_choices(self, basic_join_story):
+        """Initially only section 0 choices should be visible."""
+        engine = BardEngine(basic_join_story)
+        output = engine.current()
+
+        choices = [c["text"] for c in output.choices]
+        assert "Apple" in choices
+        assert "Pear" in choices
+        assert "Continue" not in choices  # Section 1
+
+    def test_initial_content_stops_at_join_marker(self, basic_join_story):
+        """Initial content should stop at @join marker."""
+        engine = BardEngine(basic_join_story)
+        output = engine.current()
+
+        assert "Choose your fruit" in output.content
+        assert "You chose the" not in output.content  # After @join
+
+    def test_join_choice_renders_block_content(self, basic_join_story):
+        """Choosing a @join option renders its block content."""
+        engine = BardEngine(basic_join_story)
+        output = engine.choose(0)  # Apple
+
+        assert "You pick the apple" in output.content
+
+    def test_join_choice_executes_block_variables(self, basic_join_story):
+        """Variables set in @join block should persist."""
+        engine = BardEngine(basic_join_story)
+        engine.choose(0)  # Apple
+
+        assert engine.state.get("choice") == "apple"
+
+    def test_join_choice_shows_post_join_content(self, basic_join_story):
+        """After @join choice, content after marker should appear."""
+        engine = BardEngine(basic_join_story)
+        output = engine.choose(0)  # Apple
+
+        assert "You chose the apple" in output.content
+
+    def test_join_choice_advances_to_next_section(self, basic_join_story):
+        """After @join, next section's choices should appear."""
+        engine = BardEngine(basic_join_story)
+        output = engine.choose(0)  # Apple
+
+        choices = [c["text"] for c in output.choices]
+        assert "Continue" in choices
+        assert "Apple" not in choices  # Section 0 choices gone
+
+
+class TestJoinWithParsing:
+    """Test @join with compiled stories."""
+
+    def test_basic_join_compiles(self, compile_string):
+        """Basic @join syntax should compile correctly."""
+        story = compile_string("""
+:: Start
+Pick one.
+
++ [A] -> @join
+    Chose A.
+    ~ picked = "A"
+
++ [B] -> @join
+    Chose B.
+    ~ picked = "B"
+
+@join
+You picked {picked}.
++ [Done] -> End
+
+:: End
+Done.
+""")
+        # Check structure
+        start = story["passages"]["Start"]
+        assert len(start["choices"]) == 3  # A, B, Done
+
+        # Check @join choices have block_content
+        a_choice = start["choices"][0]
+        assert a_choice["target"] == "@join"
+        assert "block_content" in a_choice
+        assert a_choice["section"] == 0
+
+        # Check Done is section 1
+        done_choice = start["choices"][2]
+        assert done_choice["section"] == 1
+
+    def test_join_marker_creates_token(self, compile_string):
+        """@join marker should create join_marker token."""
+        story = compile_string("""
+:: Start
+Before.
+@join
+After.
++ [End] -> End
+
+:: End
+Done.
+""")
+        content = story["passages"]["Start"]["content"]
+        join_markers = [t for t in content if t.get("type") == "join_marker"]
+        assert len(join_markers) == 1
+        assert join_markers[0]["id"] == 0
+
+
+class TestMultipleJoins:
+    """Test multiple sequential @join markers."""
+
+    def test_two_join_sections(self, compile_string):
+        """Multiple @join markers create multiple sections."""
+        story = compile_string("""
+:: Start
+Round 1.
+
++ [A1] -> @join
+    ~ r1 = "A"
+
++ [B1] -> @join
+    ~ r1 = "B"
+
+@join
+Round 1 done.
+Round 2.
+
++ [A2] -> @join
+    ~ r2 = "A"
+
++ [B2] -> @join
+    ~ r2 = "B"
+
+@join
+All done.
++ [End] -> End
+
+:: End
+Done.
+""")
+        engine = BardEngine(story)
+
+        # Round 1 choices
+        choices = [c["text"] for c in engine.current().choices]
+        assert "A1" in choices
+        assert "A2" not in choices
+
+        # Choose round 1
+        engine.choose(0)
+        choices = [c["text"] for c in engine.current().choices]
+        assert "A2" in choices
+        assert "A1" not in choices
+
+        # Choose round 2
+        output = engine.choose(1)  # B2
+        assert engine.state.get("r2") == "B"
+        choices = [c["text"] for c in output.choices]
+        assert "End" in choices
+
+
+class TestJoinWithConditions:
+    """Test @join with conditional choices."""
+
+    def test_conditional_join_choices(self, compile_string):
+        """Conditional @join choices should filter correctly."""
+        story = compile_string("""
+:: Start
+~ has_key = True
+~ has_sword = False
+Pick tool.
+
++ {has_key} [Use key] -> @join
+    Key used.
+
++ {has_sword} [Use sword] -> @join
+    Sword used.
+
++ [Nothing] -> @join
+    Nothing used.
+
+@join
+Done.
++ [End] -> End
+
+:: End
+Bye.
+""")
+        engine = BardEngine(story)
+        choices = [c["text"] for c in engine.current().choices]
+
+        assert "Use key" in choices
+        assert "Nothing" in choices
+        assert "Use sword" not in choices  # has_sword is False
+
+
+class TestJoinWithSticky:
+    """Test @join with one-time (non-sticky) choices."""
+
+    def test_one_time_join_choice_disappears(self, compile_string):
+        """One-time @join choices should not reappear."""
+        story = compile_string("""
+:: Start
+~ count = 0
+Pick.
+
+* [One-time] -> @join
+    ~ count = count + 1
+
++ [Repeatable] -> @join
+    ~ count = count + 1
+
+@join
+Count: {count}
++ [Again] -> Start
++ [End] -> End
+
+:: End
+Done.
+""")
+        engine = BardEngine(story)
+
+        # Both visible initially
+        choices = [c["text"] for c in engine.current().choices]
+        assert "One-time" in choices
+        assert "Repeatable" in choices
+
+        # Use one-time
+        engine.choose(0)
+        engine.choose(0)  # Again -> Start
+
+        # One-time gone
+        choices = [c["text"] for c in engine.current().choices]
+        assert "One-time" not in choices
+        assert "Repeatable" in choices
+
+
+class TestJoinWithUndoRedo:
+    """Test @join interaction with undo/redo."""
+
+    def test_undo_restores_section_index(self, compile_string):
+        """Undo should restore the section index."""
+        story = compile_string("""
+:: Start
+~ x = 0
+Pick.
+
++ [Set 1] -> @join
+    ~ x = 1
+
++ [Set 2] -> @join
+    ~ x = 2
+
+@join
+x = {x}
++ [End] -> End
+
+:: End
+Done.
+""")
+        engine = BardEngine(story)
+
+        # Make choice
+        engine.choose(0)
+        assert engine.state.get("x") == 1
+
+        # Undo
+        engine.undo()
+        assert engine.state.get("x") == 0
+
+        # Should be back at section 0
+        choices = [c["text"] for c in engine.current().choices]
+        assert "Set 1" in choices
+        assert "End" not in choices
+
+    def test_redo_restores_after_undo(self, compile_string):
+        """Redo should restore state after undo."""
+        story = compile_string("""
+:: Start
+~ x = 0
++ [Set 1] -> @join
+    ~ x = 1
+@join
+Done.
++ [End] -> End
+:: End
+Bye.
+""")
+        engine = BardEngine(story)
+        engine.choose(0)
+        engine.undo()
+        engine.redo()
+
+        assert engine.state.get("x") == 1
+
+
+class TestJoinWithHooks:
+    """Test @join with hooks system."""
+
+    def test_hook_in_join_block(self, compile_string):
+        """Hooks registered in @join blocks should work."""
+        story = compile_string("""
+:: Start
+~ counter = 0
+Pick.
+
++ [Register] -> @join
+    @hook turn_end Counter
+
++ [Skip] -> @join
+    Skip.
+
+@join
+Counter: {counter}
++ [Continue] -> Room
+
+:: Counter
+~ counter = counter + 1
+
+:: Room
+Room.
++ [Stay] -> Room
+""")
+        engine = BardEngine(story)
+
+        # Register hook
+        engine.choose(0)
+        assert engine.state.get("counter") == 1  # Hook fired
+
+        # Continue
+        engine.choose(0)
+        assert engine.state.get("counter") == 2  # Hook fired again
+
+
+class TestMixedJoinAndRegular:
+    """Test passages with both @join and regular choices."""
+
+    def test_regular_choice_exits_join_flow(self, compile_string):
+        """Regular choice should navigate away, ignoring @join."""
+        story = compile_string("""
+:: Start
+Options.
+
++ [Stay] -> @join
+    Staying.
+
++ [Leave] -> Left
+
+@join
+Still here.
++ [Continue] -> End
+
+:: Left
+You left.
+
+:: End
+Done.
+""")
+        engine = BardEngine(story)
+
+        # Choose "Leave" (regular choice)
+        engine.choose(1)
+
+        assert engine.current_passage_id == "Left"
+        assert "You left" in engine.current().content


### PR DESCRIPTION
- **@join Directive** - Inline choice blocks that merge back together (like Ink gathers)
  - `+ [Choice] -> @join` with indented block content below the choice
  - `@join` marker where all choices merge back together
  - Block content renders only when that choice is selected
  - Variables set in blocks persist after the merge
  - Multiple sequential `@join` markers per passage (sections)
  - Works with conditional choices (`+ {cond} [Text] -> @join`)
  - Works with one-time choices (`* [Text] -> @join`)
  - Compatible with hooks (`@hook`/`@unhook` in blocks)
  - Full undo/redo support (section index in snapshots)
  - pytest tests: `tests/test_join.py`